### PR TITLE
replace generating octagon route with generating diamond routes

### DIFF
--- a/src/findCoordinatesWithApi.js
+++ b/src/findCoordinatesWithApi.js
@@ -3,24 +3,17 @@ const geometry = require('spherical-geometry-js');
 function findCoordinates(startPoint, distance) {
 
   var distanceInMetres = distance * 1000;
-  const divideFactor = 6.1229488;
-  const offsetFactor = 0.7303821338
-  var offsetDistance = distanceInMetres * offsetFactor;
 
-  var centrePoint = geometry.computeOffset(startPoint, offsetDistance/divideFactor, 0)
+  var bearingsOptions = [[45, 0, 315], [135, 90, 45], [225, 180, 135], [315, 270, 225]]
+  var bearings = (bearingsOptions[Math.floor (Math.random() * bearingsOptions.length)])
 
   var startPointFormatted = geometry.computeOffset(startPoint, 0, 0);
-  var wayPointA = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 135)
-  var wayPointB = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 90)
-  var wayPointC = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 45)
-  var wayPointD = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 0)
-  var wayPointE = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 315)
-  var wayPointF = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 270)
-  var wayPointG = geometry.computeOffset(centrePoint, offsetDistance/divideFactor, 225)
+  var wayPointA = geometry.computeOffset(startPoint, distanceInMetres/4, bearings[0]);
+  var wayPointB = geometry.computeOffset(startPoint, distanceInMetres/2.828, bearings[1]);
+  var wayPointC = geometry.computeOffset(startPoint, distanceInMetres/4, bearings[2]);
 
-  routeCoordinates = [startPointFormatted.toJSON(), wayPointA.toJSON(), wayPointB.toJSON(), wayPointC.toJSON(), wayPointD.toJSON(), wayPointE.toJSON(), wayPointF.toJSON(), wayPointG.toJSON()];
+  routeCoordinates = [startPointFormatted.toJSON(), wayPointA.toJSON(), wayPointB.toJSON(), wayPointC.toJSON()];
   return routeCoordinates;
-
-}
+};
 
 module.exports = findCoordinates;


### PR DESCRIPTION
Overwrite fundCoordinates function to generate diamond routes in random directions instead of north-facing octagonal route